### PR TITLE
Update trim_osc.py

### DIFF
--- a/trim_osc.py
+++ b/trim_osc.py
@@ -208,5 +208,5 @@ for sec in root:
 # save modified osc
 of = sys.stdout.buffer if options.output == '-' else open(options.output, 'wb')
 if options.gzip:
-    of = gzip.GzipFile(fileobj=of)
+    of = gzip.GzipFile(fileobj=of, mode='w')
 of.write(etree.tostring(tree))


### PR DESCRIPTION
вызвано предупреждением 
trim_osc.py:211: FutureWarning: GzipFile was opened for writing, but this will change in future Python releases.  Specify the mode argument for opening it for writing.